### PR TITLE
Setup Dependabot to update go modules automatically

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "go:modules"
+    directory: "/"
+    update_schedule: "daily"
+    default_labels:
+      - "dependencies"
+      - "dependabot"


### PR DESCRIPTION
## WHAT

This pull request adds Dependabot config to update go modules automatically.

## WHY

Keep updating dependencies easily.